### PR TITLE
fix default format method

### DIFF
--- a/lua/symbol-usage/options.lua
+++ b/lua/symbol-usage/options.lua
@@ -32,24 +32,23 @@ S._default_opts = {
   kinds = { SymbolKind.Function, SymbolKind.Method },
   vt_position = 'above',
   text_format = function(symbol)
-    -- keep it first `nil` for correct concat
-    local refs, defs, impls
+    local fragments = {}
 
     if symbol.references then
       local usage = symbol.references <= 1 and 'usage' or 'usages'
       local num = symbol.references == 0 and 'no' or symbol.references
-      refs = ('%s %s'):format(num, usage)
+      table.insert(fragments, ('%s %s'):format(num, usage))
     end
 
     if symbol.definition then
-      defs = symbol.definition .. ' defs'
+      table.insert(fragments, symbol.definition .. ' defs')
     end
 
     if symbol.implementation then
-      impls = symbol.implementation .. ' impls'
+      table.insert(fragments, symbol.implementation .. ' impls')
     end
 
-    return table.concat({ refs, defs, impls }, ', ')
+    return table.concat(fragments, ', ')
   end,
   references = { enabled = true, include_declaration = false },
   definition = { enabled = false },


### PR DESCRIPTION
The default format callback errors with `invalid value (nil) at index 2 in table for 'concat'`, when setting eg. definitions to disabled and implementations to enabled. This is because concat doesn't work with tables that have nils in the middle.