### PR TITLE
fix: get_buf_works nil check in toggle api

### DIFF
--- a/lua/symbol-usage/init.lua
+++ b/lua/symbol-usage/init.lua
@@ -27,7 +27,7 @@ end
 
 function M.toggle()
   local bufnr = vim.api.nvim_get_current_buf()
-  if state.get_buf_workers(bufnr) then
+  if next(state.get_buf_workers(bufnr)) ~= nil then
     buf.clear_buffer(bufnr)
   else
     buf.attach_buffer(bufnr)


### PR DESCRIPTION
hey,  I got the `get_buf_workers` function 
```lua 
function state.get_buf_workers(buf)
  return state.buffers[buf] or {}
end
```
witch never returns nil.

So the nil check in `M.toggle` api will never run `buf.attach_buffer(bufnr)`.
This fix it and make toggle api useful.