### PR TITLE
Stack function `usage` on one line

### DIFF
--- a/lua/symbol-usage/options.lua
+++ b/lua/symbol-usage/options.lua
@@ -40,13 +40,13 @@ S._default_opts = {
   kinds_filter = {},
   vt_position = 'above',
   request_pending_text = 'loading...',
-  text_format = function(symbol, related_count)
+  text_format = function(symbol)
     local fragments = {}
 
     -- Indicator that shows if there are any other symbols in the same line
     local stacked_functions = (function()
-      if related_count > 0 then
-        return "+" .. ("%s"):format(related_count)
+      if symbol.stacked_count > 0 then
+        return (" | +%s"):format(symbol.stacked_count)
       end
       return ""
     end)()
@@ -54,7 +54,7 @@ S._default_opts = {
     if symbol.references then
       local usage = symbol.references <= 1 and 'usage' or 'usages'
       local num = symbol.references == 0 and 'no' or symbol.references
-      table.insert(fragments, ('%s %s %s'):format(num, usage, stacked_functions))
+      table.insert(fragments, ('%s %s'):format(num, usage))
     end
 
     if symbol.definition then
@@ -65,7 +65,7 @@ S._default_opts = {
       table.insert(fragments, symbol.implementation .. ' impls')
     end
 
-    return table.concat(fragments, ', ')
+    return table.concat(fragments, ', ') .. stacked_functions
   end,
   references = { enabled = true, include_declaration = false },
   definition = { enabled = false },

--- a/lua/symbol-usage/options.lua
+++ b/lua/symbol-usage/options.lua
@@ -40,13 +40,21 @@ S._default_opts = {
   kinds_filter = {},
   vt_position = 'above',
   request_pending_text = 'loading...',
-  text_format = function(symbol)
+  text_format = function(symbol, related_count)
     local fragments = {}
+
+    -- Indicator that shows if there are any other symbols in the same line
+    local stacked_functions = (function()
+      if related_count > 0 then
+        return "+" .. ("%s"):format(related_count)
+      end
+      return ""
+    end)()
 
     if symbol.references then
       local usage = symbol.references <= 1 and 'usage' or 'usages'
       local num = symbol.references == 0 and 'no' or symbol.references
-      table.insert(fragments, ('%s %s'):format(num, usage))
+      table.insert(fragments, ('%s %s %s'):format(num, usage, stacked_functions))
     end
 
     if symbol.definition then

--- a/lua/symbol-usage/options.lua
+++ b/lua/symbol-usage/options.lua
@@ -13,7 +13,7 @@ local SymbolKind = vim.lsp.protocol.SymbolKind
 
 ---@alias VirtualHlText string|table<number, { text: string, hl_group: string }}>
 
----@alias Formater function(symbol: Symbol): VirtualHlText
+---@alias Formatter function(symbol: Symbol): VirtualHlText
 ---@alias VTPosition 'above'|'end_of_line'|'textwidth'|'signcolumn'
 ---@alias filterKind function(data: { symbol:table, parent:table, bufnr:integer }): boolean
 ---User options to `symbol-usage.nvim`
@@ -21,7 +21,7 @@ local SymbolKind = vim.lsp.protocol.SymbolKind
 ---@field hl? table<string, any> `nvim_set_hl`-like options for highlight virtual text
 ---@field kinds? lsp.SymbolKind[] Symbol kinds what need to be count (see `lsp.SymbolKind`)
 ---@field kinds_filter? table<lsp.SymbolKind, filterKind[]> Additional filter for kinds. Recommended use in the filetypes override table.
----@field text_format? Formater Function to format virtual text. Must return string or table with (text, hl_group) pair, e.g. `{ { '1 usage', 'Constant' } }`
+---@field text_format? Formatter Function to format virtual text. Must return string or table with (text, hl_group) pair, e.g. `{ { '1 usage', 'Constant' } }`
 ---@field references? ReferencesOpts Opts for references
 ---@field definition? DefinitionOpts Opts for definitions
 ---@field implementation? ImplementationOpts Opts for implementations

--- a/lua/symbol-usage/utils.lua
+++ b/lua/symbol-usage/utils.lua
@@ -4,6 +4,20 @@ M.NS = vim.api.nvim_create_namespace('__symbol__')
 M.GROUP = vim.api.nvim_create_augroup('__symbol__', { clear = true })
 M.NESTED_GROUP = vim.api.nvim_create_augroup('__symbol_nested__', { clear = true })
 
+---Check if a table contains a value
+---@param tbl table
+---@param x any
+---@return boolean
+function M.table_contains(tbl, x)
+  local found = false
+  for _, v in pairs(tbl) do
+    if v == x then
+      found = true
+    end
+  end
+  return found
+end
+
 ---Check if client supports method
 ---@param client lsp.Client
 ---@param method string

--- a/lua/symbol-usage/worker.lua
+++ b/lua/symbol-usage/worker.lua
@@ -40,11 +40,11 @@ end
 function W:run(check_version)
   local ft = vim.bo[self.bufnr].filetype
   local no_run = not state.active
-    or vim.tbl_contains(self.opts.disable.lsp, self.client.name)
-    or vim.tbl_contains(self.opts.disable.filetypes, ft)
-    or u.some(self.opts.disable.cond, function(cb)
-      return cb(self.bufnr)
-    end)
+      or vim.tbl_contains(self.opts.disable.lsp, self.client.name)
+      or vim.tbl_contains(self.opts.disable.filetypes, ft)
+      or u.some(self.opts.disable.cond, function(cb)
+        return cb(self.bufnr)
+      end)
 
   if no_run then
     return

--- a/lua/symbol-usage/worker.lua
+++ b/lua/symbol-usage/worker.lua
@@ -11,6 +11,7 @@ local ns = u.NS
 ---@field references? integer Count of references
 ---@field definition? integer Count of definitions
 ---@field implementation? integer Count of implementations
+---@field stacked_count? integer Count of symbols that are on the same line but not displayed
 
 ---@class Worker
 ---@field bufnr number Buffer id
@@ -129,7 +130,10 @@ function W:mock_symbol(symbol_id, pos)
   local mock = {}
   if self.opts.request_pending_text then
     -- Book a place for a virtual text
-    mock = { mark_id = self:set_extmark(symbol_id, pos.line) }
+    mock = {
+      mark_id = self:set_extmark(symbol_id, pos.line),
+      stacked_count = 0
+    }
   end
   self.symbols[symbol_id] = mock
 end
@@ -138,7 +142,11 @@ end
 ---@param symbol_tree table
 ---@return table
 function W:traversal(symbol_tree)
-  local booked_lines = {}
+  local booked_lines = {
+    references = {},
+    definition = {},
+    implementation = {}
+  }
 
   local function _walk(data, parent, actual)
     for _, symbol in ipairs(data) do
@@ -152,32 +160,32 @@ function W:traversal(symbol_tree)
           symbol.detail and symbol.detail or '',
         })
 
-        for _, method in ipairs({ 'references', 'definition', 'implementation' }) do
+        for _, method in pairs({ 'references', 'definition', 'implementation' }) do
           if self:is_need_count(symbol, method, parent) then
-            if not u.table_contains(booked_lines, symbol.range.start.line) then
-              table.insert(booked_lines, symbol.range.start.line)
+            if not u.table_contains(booked_lines[method] or {}, symbol.range.start.line) then
+              table.insert(booked_lines[method], symbol.range.start.line)
 
               -- If symbol is new, add mock
-              if not self.symbols[symbol_id] then
-                self:mock_symbol(symbol_id, pos)
+              if not self.symbols[symbol_id] or not actual[symbol_id] then
+                if not self.symbols[symbol_id] then self:mock_symbol(symbol_id, pos) end
+
+                -- Collect actual symbols to remove irrelevant ones afterward
+                actual[symbol_id] = {
+                  methods = { [method] = 0 },
+                  symbol_id = symbol_id,
+                  symbol = symbol,
+                  render = true,
+                  line = symbol.range.start.line,
+                  start_character = symbol.range.start.character
+                }
               end
 
-              -- Collect actual symbols to remove irrelevant ones afterward
-              actual[symbol_id] = {
-                method = method,
-                symbol_id = symbol_id,
-                symbol = symbol,
-                alive = true,
-                render = true,
-                refers_to_line = symbol.range.start.line
-              }
-
-              -- self:count_method(method, symbol_id, symbol)
+              actual[symbol_id].methods[method] = 0
             else
               actual[symbol_id] = {
-                alive = true,
+                methods = method,
                 render = false,
-                refers_to_line = symbol.range.start.line
+                line = symbol.range.start.line,
               }
             end
           end
@@ -193,27 +201,46 @@ function W:traversal(symbol_tree)
   end
 
   return (function()
-    local walk_result = _walk(symbol_tree, '', {})
+    local function sort_by_start_character(a, b)
+      return a.range.start.character < b.range.start.character
+    end
+
+    local sorted_data = {}
+    for _, item in ipairs(symbol_tree) do
+      table.insert(sorted_data, item)
+    end
+    table.sort(sorted_data, sort_by_start_character)
+
+    local walk_result = _walk(sorted_data, '', {})
+    for _, element in pairs(self.symbols) do element.stacked_count = 0 end
 
     local result = {}
     for key, value in pairs(walk_result) do
-      if value.alive and value.render then
-        local relatedCount = 0
+      if value.render then
         for _, otherValue in pairs(walk_result) do
-          if otherValue.alive and not otherValue.render and otherValue.refers_to_line == value.refers_to_line then
-            relatedCount = relatedCount + 1
+          if not otherValue.render and otherValue.line == value.line then
+            value.methods[otherValue.methods] = value.methods[otherValue.methods] + 1
+
+            self.symbols[key].stacked_count = self.symbols[key].stacked_count + 1
           end
         end
-        value.related_count = relatedCount
         result[key] = value
-      elseif not value.render and value.alive then
       else
         result[key] = value
       end
     end
 
+    -- Deleting elements with `value.render == false`
+    for key, value in pairs(result) do
+      if not value.render then
+        result[key] = nil
+      end
+    end
+
     for _, value in pairs(result) do
-      self:count_method(value.method, value.symbol_id, value.symbol, value.related_count)
+      for method_name, _ in pairs(value.methods) do
+        self:count_method(method_name, value.symbol_id, value.symbol)
+      end
     end
 
     return result
@@ -226,7 +253,7 @@ end
 ---@param count table<Method, integer>|nil
 ---@param id integer|nil
 ---@return integer? Extmark id
-function W:set_extmark(symbol_id, line, count, id, related_count)
+function W:set_extmark(symbol_id, line, count, id)
   -- The buffer can already be removed from the state when the woker finishes. See issue #32
   -- Prevent drawing already unneeded extmarks
   if next(state.get_buf_workers(self.bufnr)) == nil then
@@ -236,7 +263,7 @@ function W:set_extmark(symbol_id, line, count, id, related_count)
   local text = self.opts.request_pending_text
   if self.symbols[symbol_id] and count then
     count = vim.tbl_deep_extend('force', self.symbols[symbol_id], count)
-    text = self.opts.text_format(count, related_count)
+    text = self.opts.text_format(count)
   end
 
   if not text then
@@ -251,7 +278,7 @@ end
 ---Count method for symbol
 ---@param method Method
 ---@param symbol_id string
-function W:count_method(method, symbol_id, symbol, related_count)
+function W:count_method(method, symbol_id, symbol)
   if not u.support_method(self.client, method) then
     return
   end
@@ -282,7 +309,7 @@ function W:count_method(method, symbol_id, symbol, related_count)
       id = record.mark_id
     end
 
-    id = self:set_extmark(symbol_id, params.position.line, { [method] = count }, id, related_count)
+    id = self:set_extmark(symbol_id, params.position.line, { [method] = count }, id)
     if record and id then
       record.mark_id = id
       record[method] = count


### PR DESCRIPTION
This pull request implements the functionality of collecting multiple usage symbols into a single string if they are on the same line.
Additionally, this pull request fixes the bug described in [#43](https://github.com/Wansmer/symbol-usage.nvim/issues/43).

### Explanation of the bug

The expression was outputting multiple functions in a single line. The `traversal` function processed all of them and put them in one line, and they were stacked.

https://pastebin.com/xEDP4p99 -  "textDocument/documentSymbol" untraversed (LSP)
https://pastebin.com/vuwrTFbC -  "textDocument/documentSymbol" after traversal
![image](https://github.com/Wansmer/symbol-usage.nvim/assets/72041440/0a246e98-3a3f-44a8-9a1e-89d8c3958e6b)
[outline](https://github.com/hedyhli/outline.nvim?tab=readme-ov-file#installation) view

### Work accomplished
![image](https://github.com/Wansmer/symbol-usage.nvim/assets/72041440/b7630889-b3df-4c4c-95bf-8c5f6b879cc4)
before the changes

![image](https://github.com/Wansmer/symbol-usage.nvim/assets/72041440/b708e8ea-4ffb-4a09-95d7-e31cc0d818a5)
after the changes