### PR TITLE
feat: symbol filtering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ require('symbol-usage').setup({
   -- filetypes = {},
   ---@type 'start'|'end' At which position of `symbol.selectionRange` the request to the lsp server should start. Default is `end` (try changing it to `start` if the symbol counting is not correct).
   symbol_request_pos = 'end', -- Recommended redefine only in `filetypes` override table
+  ---@type (fun(ctx: lsp.HandlerContext):fun(symbol: lsp.Location): boolean)?
+  -- This is a function factory that takes the LSP context as a parameter and
+  -- produce a filter function for vim.tbl_filter. This can be used to exclude
+  -- certain references/definition/implementation from being included in the
+  -- count. See [Filtering Symbols] for details.
+  symbol_filter = nil,
   ---@type LoggerConfig
   log = { enabled = false },
 })
@@ -337,6 +343,28 @@ I would like to know how many times an arrow function is used, but keeping track
 For this purpose, you can define additional filters that will check that the variable contains exactly the function and not some other value.
 
 You can see implementation examples [here](lua/symbol-usage/langs.lua).
+
+## Filtering Symbols
+
+Sometimes we want to exclude certain definition/references (eg. references from tests). 
+You can use the `symbol_filter` option to define a custom filter. For example,
+if you want to exclude the references for a symbol when the references are from
+a test file (which usually lies in the `tests/` directory), you can use the following
+filter:
+```lua
+symbol_filter = function(ctx)
+  return function(symbol)
+    if ctx.method == vim.lsp.protocol.Methods.textDocument_references then
+      -- if the LSP request is 'textDocument/references', do not count it if the URI contains `tests/`
+      return string.find(symbol.uri, "tests") ~= nil
+    else
+      -- for other types of LSP requests, do not apply a filter and always count
+      -- the occurrence.
+      return true
+    end
+  end
+end
+```
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ symbol_filter = function(ctx)
   return function(symbol)
     if ctx.method == vim.lsp.protocol.Methods.textDocument_references then
       -- if the LSP request is 'textDocument/references', do not count it if the URI contains `tests/`
-      return string.find(symbol.uri, "tests") ~= nil
+      return string.find(symbol.uri, "tests") == nil
     else
       -- for other types of LSP requests, do not apply a filter and always count
       -- the occurrence.

--- a/lua/symbol-usage/options.lua
+++ b/lua/symbol-usage/options.lua
@@ -32,6 +32,7 @@ local SymbolKind = vim.lsp.protocol.SymbolKind
 ---@field disable? { lsp?: string[], filetypes?: string[], cond?: function[] } Disables `symbol-usage.nvim' for specific LSPs, filetypes, or on custom conditions. The function in the `cond` list takes an argument `bufnr` and returns a boolean. If it returns true, `symbol-usage` will not run in that buffer.
 ---@field filetypes UserOpts[] To override opts for specific filetypes. Missing field came from common opts
 ---@field log LoggerConfig
+---@field symbol_filter? fun(ctx: lsp.HandlerContext):(fun(symbol: lsp.Location): boolean)
 
 local S = {}
 
@@ -78,6 +79,7 @@ S._default_opts = {
     vue = langs.javascript,
   },
   log = { enabled = false },
+  symbol_filter = nil,
 }
 
 S.opts = {}

--- a/lua/symbol-usage/worker.lua
+++ b/lua/symbol-usage/worker.lua
@@ -2,6 +2,7 @@ local u = require('symbol-usage.utils')
 local o = require('symbol-usage.options')
 local state = require('symbol-usage.state')
 local log = require('symbol-usage.logger')
+local options = require('symbol-usage.options')
 
 local ns = u.NS
 
@@ -320,6 +321,11 @@ function W:count_method(method, symbol_id, symbol)
         log.warn('Buffer version mismatch for buffer: %d', self.bufnr)
         return
       end
+    end
+
+    local symbol_filter = options.get_ft_or_default(ctx.bufnr).symbol_filter
+    if symbol_filter ~= nil then
+      response = vim.tbl_filter(symbol_filter(ctx), response)
     end
 
     -- Some clients return `nil` if there are no references (e.g., `lua_ls`)

--- a/lua/symbol-usage/worker.lua
+++ b/lua/symbol-usage/worker.lua
@@ -324,7 +324,7 @@ function W:count_method(method, symbol_id, symbol)
     end
 
     local symbol_filter = options.get_ft_or_default(ctx.bufnr).symbol_filter
-    if symbol_filter ~= nil then
+    if symbol_filter ~= nil and response ~= nil then
       response = vim.tbl_filter(symbol_filter(ctx), response)
     end
 


### PR DESCRIPTION
Implement #69 

I implemented something more powerful than what's mentioned, because I realised that the filtering for references may not be appropriate for definition/implementation.

I solved this problem by exposing `lsp.HandlerContext`, which allows users to write custom logics to differentiate between different LSP requests.